### PR TITLE
Only populate secondary endpoints if the config is set

### DIFF
--- a/services/common/clients/config/trusted_server_config_client.cc
+++ b/services/common/clients/config/trusted_server_config_client.cc
@@ -109,7 +109,12 @@ absl::Status TrustedServersConfigClient::Init(
 
 bool TrustedServersConfigClient::HasParameter(
     absl::string_view name) const noexcept {
-  return config_entries_map_.contains(name) && config_entries_map_.at(name) != kEmptyValue;
+  return config_entries_map_.contains(name);
+}
+
+bool TrustedServersConfigClient::HasParameterWithValue(
+    absl::string_view name) const noexcept {
+  return HasParameter(name) && config_entries_map_.at(name) != kEmptyValue;
 }
 
 absl::string_view TrustedServersConfigClient::GetStringParameter(

--- a/services/common/clients/config/trusted_server_config_client.cc
+++ b/services/common/clients/config/trusted_server_config_client.cc
@@ -109,7 +109,7 @@ absl::Status TrustedServersConfigClient::Init(
 
 bool TrustedServersConfigClient::HasParameter(
     absl::string_view name) const noexcept {
-  return config_entries_map_.contains(name);
+  return config_entries_map_.contains(name) && config_entries_map_.at(name) != kEmptyValue;
 }
 
 absl::string_view TrustedServersConfigClient::GetStringParameter(

--- a/services/common/clients/config/trusted_server_config_client.h
+++ b/services/common/clients/config/trusted_server_config_client.h
@@ -73,6 +73,9 @@ class TrustedServersConfigClient {
   // Checks if a parameter is present in the config client.
   bool HasParameter(absl::string_view name) const noexcept;
 
+  // Checks if a parameter is present with a non-empty value in the config client.
+  bool HasParameterWithValue(absl::string_view name) const noexcept;
+
   // Fetches the string value for the specified config parameter.
   absl::string_view GetStringParameter(absl::string_view name) const noexcept;
 

--- a/services/common/encryption/key_fetcher_factory.cc
+++ b/services/common/encryption/key_fetcher_factory.cc
@@ -86,7 +86,7 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
     return std::make_unique<server_common::FakeKeyFetcherManager>();
   }
 
-  google::scp::cpio::PrivateKeyVendingEndpoint primary, secondary;
+  google::scp::cpio::PrivateKeyVendingEndpoint primary;
   primary.account_identity =
       config_client.GetStringParameter(PRIMARY_COORDINATOR_ACCOUNT_IDENTITY);
   primary.private_key_vending_service_endpoint =
@@ -95,14 +95,6 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
   primary.service_region =
       config_client.GetStringParameter(PRIMARY_COORDINATOR_REGION);
 
-  secondary.account_identity =
-      config_client.GetStringParameter(SECONDARY_COORDINATOR_ACCOUNT_IDENTITY);
-  secondary.private_key_vending_service_endpoint =
-      config_client.GetStringParameter(
-          SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT);
-  secondary.service_region =
-      config_client.GetStringParameter(SECONDARY_COORDINATOR_REGION);
-
   if (config_client.HasParameter(GCP_PRIMARY_WORKLOAD_IDENTITY_POOL_PROVIDER)) {
     PS_VLOG(3) << "Found GCP Workload Identity Pool Provider, proceeding...";
     primary.gcp_private_key_vending_service_cloudfunction_url =
@@ -110,18 +102,35 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
             GCP_PRIMARY_KEY_SERVICE_CLOUD_FUNCTION_URL);
     primary.gcp_wip_provider = config_client.GetStringParameter(
         GCP_PRIMARY_WORKLOAD_IDENTITY_POOL_PROVIDER);
+  }
 
-    secondary.gcp_private_key_vending_service_cloudfunction_url =
+  std::vector<google::scp::cpio::PrivateKeyVendingEndpoint> secondaries{};
+  if (config_client.HasParameter(SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)) {
+    google::scp::cpio::PrivateKeyVendingEndpoint secondary;
+
+    secondary.account_identity =
+        config_client.GetStringParameter(SECONDARY_COORDINATOR_ACCOUNT_IDENTITY);
+    secondary.private_key_vending_service_endpoint =
         config_client.GetStringParameter(
-            GCP_SECONDARY_KEY_SERVICE_CLOUD_FUNCTION_URL);
-    secondary.gcp_wip_provider = config_client.GetStringParameter(
-        GCP_SECONDARY_WORKLOAD_IDENTITY_POOL_PROVIDER);
+            SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT);
+    secondary.service_region =
+        config_client.GetStringParameter(SECONDARY_COORDINATOR_REGION);
+
+    if (config_client.HasParameter(GCP_PRIMARY_WORKLOAD_IDENTITY_POOL_PROVIDER)) {
+      secondary.gcp_private_key_vending_service_cloudfunction_url =
+          config_client.GetStringParameter(
+              GCP_SECONDARY_KEY_SERVICE_CLOUD_FUNCTION_URL);
+      secondary.gcp_wip_provider = config_client.GetStringParameter(
+          GCP_SECONDARY_WORKLOAD_IDENTITY_POOL_PROVIDER);
+    }
+
+    secondaries.push_back(secondary);
   }
 
   absl::Duration private_key_ttl = absl::Seconds(
       config_client.GetIntParameter(PRIVATE_KEY_CACHE_TTL_SECONDS));
   std::unique_ptr<PrivateKeyFetcherInterface> private_key_fetcher =
-      server_common::PrivateKeyFetcherFactory::Create(primary, {secondary},
+      server_common::PrivateKeyFetcherFactory::Create(primary, secondaries,
                                                       private_key_ttl);
 
   absl::Duration key_refresh_flow_run_freq = absl::Seconds(

--- a/services/common/encryption/key_fetcher_factory.cc
+++ b/services/common/encryption/key_fetcher_factory.cc
@@ -105,7 +105,7 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
   }
 
   std::vector<google::scp::cpio::PrivateKeyVendingEndpoint> secondaries{};
-  if (config_client.HasParameter(SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)) {
+  if (config_client.HasParameterWithValue(SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)) {
     google::scp::cpio::PrivateKeyVendingEndpoint secondary;
 
     secondary.account_identity =


### PR DESCRIPTION
First change to support Azure port. It come about as a result of the Azure KMS implementation being different - there is only ever one KMS and so there is never a SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT. 

This change does two main things:
1. Modifies `TrustedServersConfigClient::HasParameter()` to return false when parameter is present in config_entries_map but has a default empty value. 
    - This is because all flags passed into the constructor of TrustedServersConfigClient are added to the map with the empty value
    - So if `SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT` isn't specified, `TrustedServersConfigClient::HasParameter(SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)` incorrectly returns true

2. When initialising PrivateKeyFetcherFactory, reorganises the logic so that the secondary endpoint is only included when `SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT` is set

These two changes mean that when combining primary and secondary endpoints into a single vector in the data plane, we don't get a secondary endpoint with a blank URL