### PR TITLE
Split HasParamter into two functions

### DIFF
--- a/services/common/clients/config/trusted_server_config_client.cc
+++ b/services/common/clients/config/trusted_server_config_client.cc
@@ -110,8 +110,12 @@ absl::Status TrustedServersConfigClient::Init(
 
 bool TrustedServersConfigClient::HasParameter(
     absl::string_view name) const noexcept {
-  return config_entries_map_.contains(name) &&
-         config_entries_map_.at(name) != kEmptyValue;
+  return config_entries_map_.contains(name);
+}
+
+bool TrustedServersConfigClient::HasParameterWithValue(
+    absl::string_view name) const noexcept {
+  return HasParameter(name) && config_entries_map_.at(name) != kEmptyValue;
 }
 
 absl::string_view TrustedServersConfigClient::GetStringParameter(

--- a/services/common/clients/config/trusted_server_config_client.h
+++ b/services/common/clients/config/trusted_server_config_client.h
@@ -73,6 +73,9 @@ class TrustedServersConfigClient {
   // Checks if a parameter is present in the config client.
   bool HasParameter(absl::string_view name) const noexcept;
 
+  // Checks if a parameter is present with a non-empty value in the config client.
+  bool HasParameterWithValue(absl::string_view name) const noexcept;
+
   // Fetches the string value for the specified config parameter.
   absl::string_view GetStringParameter(absl::string_view name) const noexcept;
 

--- a/services/common/encryption/key_fetcher_factory.cc
+++ b/services/common/encryption/key_fetcher_factory.cc
@@ -108,7 +108,7 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
   }
 
   std::vector<google::scp::cpio::PrivateKeyVendingEndpoint> secondaries{};
-  if (config_client.HasParameter(SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)) {
+  if (config_client.HasParameterWithValue(SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)) {
     google::scp::cpio::PrivateKeyVendingEndpoint secondary;
 
     secondary.account_identity = config_client.GetStringParameter(


### PR DESCRIPTION
To maintain existing HasParameter functionality, split the part which checks for non-empty value into a separate function

Will also merge into fix-secondary-endpoints