### PR TITLE
Fix key_fetcher_utils_test

### DIFF
--- a/services/seller_frontend_service/util/key_fetcher_utils_test.cc
+++ b/services/seller_frontend_service/util/key_fetcher_utils_test.cc
@@ -30,7 +30,7 @@ TEST(KeyFetcherUtilsTest, ParseCloudPlatformPublicKeysMap_ValidInput) {
 {
   "GCP": "https://publickeyservice.foo/v1alpha/publicKeys",
   "AWS": "https://publickeyservice.cloudfront.net/v1alpha/publicKeys",
-  "AZURE": "https://publickeyservice.bar/v1alpha/publicKeys",
+  "AZURE": "https://publickeyservice.bar/v1alpha/publicKeys"
 }
 )json";
 


### PR DESCRIPTION
When the JSON was updated with AZURE, the JSON was accidentally made to be invalid which causes the test to fail but due to an issue in the Bazel config elsewhere the test didn't run properly