### PR TITLE
Fix changed KV service repo name

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,9 +58,9 @@ http_archive(
 
 http_archive(
     name = "protected-auction-key-value-service",
-    # commit 9930c86b66880354097d5e97bff1172ea43ebcc9 2024-01-23
-    strip_prefix = "protected-auction-key-value-service-9930c86b66880354097d5e97bff1172ea43ebcc9",
+    # commit 1eee8e79e44f3ca735cfab0b716e57f81d95bd46 2023-10-26
+    strip_prefix = "protected-auction-key-value-service-1eee8e79e44f3ca735cfab0b716e57f81d95bd46",
     urls = [
-        "https://github.com/privacysandbox/protected-auction-key-value-service/archive/9930c86b66880354097d5e97bff1172ea43ebcc9.zip",
+        "https://github.com/privacysandbox/protected-auction-key-value-service/archive/1eee8e79e44f3ca735cfab0b716e57f81d95bd46.zip",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,10 +57,10 @@ http_archive(
 )
 
 http_archive(
-    name = "service_value_key_fledge_privacysandbox",
-    # commit 1eee8e79e44f3ca735cfab0b716e57f81d95bd46 2023-10-26
-    strip_prefix = "fledge-key-value-service-1eee8e79e44f3ca735cfab0b716e57f81d95bd46",
+    name = "protected-auction-key-value-service",
+    # commit 9930c86b66880354097d5e97bff1172ea43ebcc9 2024-01-23
+    strip_prefix = "protected-auction-key-value-service-9930c86b66880354097d5e97bff1172ea43ebcc9",
     urls = [
-        "https://github.com/privacysandbox/fledge-key-value-service/archive/1eee8e79e44f3ca735cfab0b716e57f81d95bd46.zip",
+        "https://github.com/privacysandbox/protected-auction-key-value-service/archive/9930c86b66880354097d5e97bff1172ea43ebcc9.zip",
     ],
 )

--- a/services/common/clients/BUILD
+++ b/services/common/clients/BUILD
@@ -221,10 +221,10 @@ cc_library(
         "@com_google_absl//absl/strings",
         "@google_privacysandbox_servers_common//src/cpp/util/status_macro:status_macros",
         "@rapidjson",
-        "@service_value_key_fledge_privacysandbox//public/applications/pas:retrieval_request_builder",
-        "@service_value_key_fledge_privacysandbox//public/applications/pas:retrieval_response_parser",
-        "@service_value_key_fledge_privacysandbox//public/query/cpp:client_utils",
-        "@service_value_key_fledge_privacysandbox//public/query/v2:get_values_v2_cc_proto",
+        "@protected-auction-key-value-service//public/applications/pas:retrieval_request_builder",
+        "@protected-auction-key-value-service//public/applications/pas:retrieval_response_parser",
+        "@protected-auction-key-value-service//public/query/cpp:client_utils",
+        "@protected-auction-key-value-service//public/query/v2:get_values_v2_cc_proto",
     ],
 )
 


### PR DESCRIPTION
The privacy sandbox KV service repo was renamed from `fledge-key-value-service` to `protected-auction-key-value-service` but the code which pulls this dependency in hasn't been updated accordingly.