### PR TITLE
Add Azure support (for v3.4.0)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -57,6 +57,9 @@ build:instance_gcp --@google_privacysandbox_servers_common//:instance=gcp
 build:instance_aws --//:instance=aws
 build:instance_aws --@google_privacysandbox_servers_common//:instance=aws
 
+build:instance_azure --//:instance=azure
+build:instance_azure --@google_privacysandbox_servers_common//:instance=azure
+
 build:platform_local --//:platform=local
 
 build:platform_aws --//:platform=aws
@@ -65,11 +68,17 @@ build:platform_aws --@google_privacysandbox_servers_common//:platform=aws
 build:platform_gcp --//:platform=gcp
 build:platform_gcp --@google_privacysandbox_servers_common//:platform=gcp
 
+build:platform_azure --//:platform=azure
+build:platform_azure --@google_privacysandbox_servers_common//:platform=azure
+
 build:local_aws --config=instance_local
 build:local_aws --config=platform_aws
 
 build:local_gcp --config=instance_local
 build:local_gcp --config=platform_gcp
+
+build:local_azure --config=instance_local
+build:local_azure --config=platform_azure
 
 build:gcp_gcp --config=instance_gcp
 build:gcp_gcp --config=platform_gcp
@@ -79,6 +88,9 @@ build:local_local --config=platform_local
 
 build:aws_aws --config=instance_aws
 build:aws_aws --config=platform_aws
+
+build:azure_azure --config=instance_azure
+build:azure_azure --config=platform_azure
 
 build:non_prod --//:build_flavor=non_prod
 build:non_prod --@google_privacysandbox_servers_common//:build_flavor=non_prod

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 # Copyright 2022 Google LLC
+# Copyright (C) Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +21,9 @@ string_flag(
     name = "instance",
     build_setting_default = "aws",
     values = [
-        "gcp",
         "aws",
+        "azure",
+        "gcp",
         "local",
     ],
 )
@@ -87,6 +89,14 @@ config_setting(
     name = "gcp_instance",
     flag_values = {
         ":instance": "gcp",
+    },
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "azure_instance",
+    flag_values = {
+        ":instance": "azure",
     },
     visibility = ["//visibility:public"],
 )

--- a/production/packaging/azure/auction_service/BUILD
+++ b/production/packaging/azure/auction_service/BUILD
@@ -1,0 +1,120 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_layer",
+)
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_files",
+)
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//:config.bzl", "LOG_ENV_VARS")
+
+pkg_files(
+    name = "server_executables",
+    srcs = [
+        "bin/init_server_basic",
+        "//services/auction_service:server",
+    ],
+    attributes = pkg_attributes(mode = "0555"),
+    prefix = "/server/bin",
+)
+
+server_binaries = [
+    ":server_executables",
+]
+
+pkg_zip(
+    name = "server_binaries",
+    srcs = server_binaries,
+)
+
+pkg_tar(
+    name = "server_binaries_tar",
+    srcs = server_binaries,
+)
+
+container_layer(
+    name = "server_binary_layer",
+    directory = "/",
+    tars = [
+        ":server_binaries_tar",
+    ],
+)
+
+container_image(
+    name = "server_docker_image",
+    base = select({
+        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64//image",
+        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64//image",
+    }),
+    cmd = [
+        "/server/bin/init_server_basic",
+    ],
+    entrypoint = ["sh"],
+    env = LOG_ENV_VARS,
+    labels = {"tee.launch_policy.log_redirect": "always"},
+    layers = [
+        ":server_binary_layer",
+    ],
+    ports = ["50051"],
+)
+
+container_test(
+    name = "structure_test",
+    size = "large",
+    configs = ["test/structure.yaml"],
+    driver = "tar",
+    image = ":server_docker_image",
+)
+
+container_test(
+    name = "commands_test",
+    size = "large",
+    configs = ["test/commands.yaml"],
+    driver = "docker",
+    image = ":server_docker_image",
+)
+
+# server artifacts
+pkg_zip(
+    name = "server_artifacts",
+    srcs = server_binaries,
+)
+
+genrule(
+    name = "copy_to_dist",
+    srcs = [
+        ":server_artifacts",
+        ":server_docker_image.tar",
+        "//api:bidding_auction_servers_descriptor_set",
+    ],
+    outs = ["copy_to_dist.bin"],
+    cmd_bash = """cat << EOF > '$@'
+mkdir -p dist/debian
+cp $(execpath :server_artifacts) dist/debian/$$(basename $(RULEDIR))_artifacts.zip
+cp $(execpath :server_docker_image.tar) dist/debian/$$(basename $(RULEDIR))_image.tar
+cp $(execpath //api:bidding_auction_servers_descriptor_set) dist
+builders/tools/normalize-dist
+EOF""",
+    executable = True,
+    local = True,
+    message = "copying server artifacts to dist/debian directory",
+)

--- a/production/packaging/azure/auction_service/bin/init_server_basic
+++ b/production/packaging/azure/auction_service/bin/init_server_basic
@@ -1,0 +1,23 @@
+#!/busybox/sh
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -x
+export GLOG_logtostderr=1
+export GLOG_stderrthreshold=0
+export GRPC_DNS_RESOLVER=native
+
+# Start the server first.
+/server/bin/server --init_config_client=true

--- a/production/packaging/azure/auction_service/test/commands.yaml
+++ b/production/packaging/azure/auction_service/test/commands.yaml
@@ -1,0 +1,24 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+# command tests require the docker toolchain
+commandTests:
+  - name: "server help"
+    command: "/server/bin/server"
+    args: ["--help"]
+    exitCode: 1

--- a/production/packaging/azure/auction_service/test/structure.yaml
+++ b/production/packaging/azure/auction_service/test/structure.yaml
@@ -1,0 +1,35 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: init_server_basic
+    path: /server/bin/init_server_basic
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: server
+    path: /server/bin/server
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: ca-certs
+    path: /etc/ssl/certs/ca-certificates.crt
+    shouldExist: true
+
+licenseTests:
+  - debian: true

--- a/production/packaging/azure/bidding_service/BUILD
+++ b/production/packaging/azure/bidding_service/BUILD
@@ -1,0 +1,120 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_layer",
+)
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_files",
+)
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//:config.bzl", "LOG_ENV_VARS")
+
+pkg_files(
+    name = "server_executables",
+    srcs = [
+        "bin/init_server_basic",
+        "//services/bidding_service:server",
+    ],
+    attributes = pkg_attributes(mode = "0555"),
+    prefix = "/server/bin",
+)
+
+server_binaries = [
+    ":server_executables",
+]
+
+pkg_zip(
+    name = "server_binaries",
+    srcs = server_binaries,
+)
+
+pkg_tar(
+    name = "server_binaries_tar",
+    srcs = server_binaries,
+)
+
+container_layer(
+    name = "server_binary_layer",
+    directory = "/",
+    tars = [
+        ":server_binaries_tar",
+    ],
+)
+
+container_image(
+    name = "server_docker_image",
+    base = select({
+        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64//image",
+        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64//image",
+    }),
+    cmd = [
+        "/server/bin/init_server_basic",
+    ],
+    entrypoint = ["sh"],
+    env = LOG_ENV_VARS,
+    labels = {"tee.launch_policy.log_redirect": "always"},
+    layers = [
+        ":server_binary_layer",
+    ],
+    ports = ["50051"],
+)
+
+container_test(
+    name = "structure_test",
+    size = "large",
+    configs = ["test/structure.yaml"],
+    driver = "tar",
+    image = ":server_docker_image",
+)
+
+container_test(
+    name = "commands_test",
+    size = "large",
+    configs = ["test/commands.yaml"],
+    driver = "docker",
+    image = ":server_docker_image",
+)
+
+# server artifacts
+pkg_zip(
+    name = "server_artifacts",
+    srcs = server_binaries,
+)
+
+genrule(
+    name = "copy_to_dist",
+    srcs = [
+        ":server_artifacts",
+        ":server_docker_image.tar",
+        "//api:bidding_auction_servers_descriptor_set",
+    ],
+    outs = ["copy_to_dist.bin"],
+    cmd_bash = """cat << EOF > '$@'
+mkdir -p dist/debian
+cp $(execpath :server_artifacts) dist/debian/$$(basename $(RULEDIR))_artifacts.zip
+cp $(execpath :server_docker_image.tar) dist/debian/$$(basename $(RULEDIR))_image.tar
+cp $(execpath //api:bidding_auction_servers_descriptor_set) dist
+builders/tools/normalize-dist
+EOF""",
+    executable = True,
+    local = True,
+    message = "copying server artifacts to dist/debian directory",
+)

--- a/production/packaging/azure/bidding_service/bin/init_server_basic
+++ b/production/packaging/azure/bidding_service/bin/init_server_basic
@@ -1,0 +1,24 @@
+#!/busybox/sh
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -x
+
+export GLOG_logtostderr=1
+export GLOG_stderrthreshold=0
+export GRPC_DNS_RESOLVER=native
+
+# Start the server first.
+/server/bin/server --init_config_client=true

--- a/production/packaging/azure/bidding_service/test/commands.yaml
+++ b/production/packaging/azure/bidding_service/test/commands.yaml
@@ -1,0 +1,24 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+# command tests require the docker toolchain
+commandTests:
+  - name: "server help"
+    command: "/server/bin/server"
+    args: ["--help"]
+    exitCode: 1

--- a/production/packaging/azure/bidding_service/test/structure.yaml
+++ b/production/packaging/azure/bidding_service/test/structure.yaml
@@ -1,0 +1,35 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: init_server_basic
+    path: /server/bin/init_server_basic
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: server
+    path: /server/bin/server
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: ca-certs
+    path: /etc/ssl/certs/ca-certificates.crt
+    shouldExist: true
+
+licenseTests:
+  - debian: true

--- a/production/packaging/azure/buyer_frontend_service/BUILD
+++ b/production/packaging/azure/buyer_frontend_service/BUILD
@@ -1,0 +1,121 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_image",
+    "container_layer",
+)
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_files",
+)
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//:config.bzl", "LOG_ENV_VARS")
+
+pkg_files(
+    name = "server_executables",
+    srcs = [
+        "bin/init_server_basic",
+        "//services/buyer_frontend_service:server",
+        "@com_github_grpc_grpc//test/cpp/util:grpc_cli",
+    ],
+    attributes = pkg_attributes(mode = "0555"),
+    prefix = "/server/bin",
+)
+
+server_binaries = [
+    ":server_executables",
+]
+
+pkg_zip(
+    name = "server_binaries",
+    srcs = server_binaries,
+)
+
+pkg_tar(
+    name = "server_binaries_tar",
+    srcs = server_binaries,
+)
+
+container_layer(
+    name = "server_binary_layer",
+    directory = "/",
+    tars = [
+        ":server_binaries_tar",
+    ],
+)
+
+container_image(
+    name = "server_docker_image",
+    base = select({
+        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64//image",
+        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64//image",
+    }),
+    cmd = [
+        "/server/bin/init_server_basic",
+    ],
+    entrypoint = ["sh"],
+    env = LOG_ENV_VARS,
+    labels = {"tee.launch_policy.log_redirect": "always"},
+    layers = [
+        ":server_binary_layer",
+    ],
+    ports = ["50051"],
+)
+
+container_test(
+    name = "structure_test",
+    size = "large",
+    configs = ["test/structure.yaml"],
+    driver = "tar",
+    image = ":server_docker_image",
+)
+
+container_test(
+    name = "commands_test",
+    size = "large",
+    configs = ["test/commands.yaml"],
+    driver = "docker",
+    image = ":server_docker_image",
+)
+
+# server artifacts
+pkg_zip(
+    name = "server_artifacts",
+    srcs = server_binaries,
+)
+
+genrule(
+    name = "copy_to_dist",
+    srcs = [
+        ":server_artifacts",
+        ":server_docker_image.tar",
+        "//api:bidding_auction_servers_descriptor_set",
+    ],
+    outs = ["copy_to_dist.bin"],
+    cmd_bash = """cat << EOF > '$@'
+mkdir -p dist/debian
+cp $(execpath :server_artifacts) dist/debian/$$(basename $(RULEDIR))_artifacts.zip
+cp $(execpath :server_docker_image.tar) dist/debian/$$(basename $(RULEDIR))_image.tar
+cp $(execpath //api:bidding_auction_servers_descriptor_set) dist
+builders/tools/normalize-dist
+EOF""",
+    executable = True,
+    local = True,
+    message = "copying server artifacts to dist/debian directory",
+)

--- a/production/packaging/azure/buyer_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/buyer_frontend_service/bin/init_server_basic
@@ -1,0 +1,28 @@
+#!/busybox/sh
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#########################################################################
+#                                                                       #
+#                             BFE Startup                               #
+#                                                                       #
+#########################################################################
+
+
+export GLOG_logtostderr=1
+export GLOG_stderrthreshold=0
+export GRPC_DNS_RESOLVER=native
+
+# Start the server.
+/server/bin/server  --init_config_client=true

--- a/production/packaging/azure/buyer_frontend_service/test/commands.yaml
+++ b/production/packaging/azure/buyer_frontend_service/test/commands.yaml
@@ -1,0 +1,24 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+# command tests require the docker toolchain
+commandTests:
+  - name: "server help"
+    command: "/server/bin/server"
+    args: ["--help"]
+    exitCode: 1

--- a/production/packaging/azure/buyer_frontend_service/test/structure.yaml
+++ b/production/packaging/azure/buyer_frontend_service/test/structure.yaml
@@ -1,0 +1,40 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: init_server_basic.sh
+    path: /server/bin/init_server_basic
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: server
+    path: /server/bin/server
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: grpc_cli
+    path: /server/bin/grpc_cli
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: ca-certs
+    path: /etc/ssl/certs/ca-certificates.crt
+    shouldExist: true
+
+licenseTests:
+  - debian: true

--- a/production/packaging/azure/lib_azure_artifacts.sh
+++ b/production/packaging/azure/lib_azure_artifacts.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright (C) Microsoft Corporation. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#######################################
+# Copy build artifacts to the workspace's dist/gcp.
+# Arguments:
+#   * the docker image tar URI
+# Globals:
+#   WORKSPACE
+#######################################
+function create_azure_dist() {
+  local -r server_image="$1"
+  local -r dist_dir="${WORKSPACE}/dist"
+  mkdir -p "${dist_dir}"/azure
+  chmod 770 "${dist_dir}" "${dist_dir}"/azure
+  cp "${WORKSPACE}/${server_image}" "${dist_dir}"/azure
+}
+
+#######################################
+# Upload image to provided repo using default gcloud config.
+# If this function fails, check that your environment has permission
+# to upload to the specified repo (gcloud default project, docker config, and service account).
+# Arguments:
+#   * the name of the service
+#   * the docker image tar URI
+#   * the azure image repo
+#   * the azure image tag
+#   * the build flavor
+# Globals:
+#   WORKSPACE
+#######################################
+function upload_image_to_repo() {
+  local -r service="$1"
+  local -r server_image="$2"
+  local -r azure_image_repo="$3"
+  local -r azure_image_tag="$4"
+  local -r build_flavor="$5"
+
+  local -r local_image_uri=bazel/production/packaging/azure/${service}:server_docker_image
+  local -r repo_image_uri="${azure_image_repo}/${service}"
+  local -r env_tag="${repo_image_uri}:${azure_image_tag}"
+  local -r git_tag="${repo_image_uri}:$(git -C ${WORKSPACE} describe --tags --always || echo no-git-version)-${build_flavor}"
+
+  printf "==== Uploading local image to Artifact Repository ${azure_image_repo} =====\n"
+  # Note: if the following commands fail, double check that the local environment has
+  # authenticated to the repo.
+  docker load -i "${WORKSPACE}/${server_image}"
+
+  # Push with env tag.
+  docker tag "${local_image_uri}" "${env_tag}"
+  docker push "${env_tag}"
+
+  # Push with git tag.
+  docker tag "${local_image_uri}" "${git_tag}"
+  docker push "${git_tag}"
+
+  # Get the image digest.
+  # Fetched format from docker inspect is: <repo url>@sha256:<64 char hash>
+  # Saved format after cut is: sha256:<64 char hash>.
+  echo $(docker inspect --format='{{index .RepoDigests 0}}' "${local_image_uri}") \
+   | cut -d '@' -f 2 > "${WORKSPACE}"/dist/azure/"${service}"_"${build_flavor}".sha256
+}

--- a/production/packaging/azure/seller_frontend_service/BUILD
+++ b/production/packaging/azure/seller_frontend_service/BUILD
@@ -1,0 +1,180 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_flatten",
+    "container_image",
+    "container_layer",
+)
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
+load(
+    "@rules_pkg//pkg:mappings.bzl",
+    "pkg_attributes",
+    "pkg_files",
+)
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//:config.bzl", "LOG_ENV_VARS")
+
+pkg_files(
+    name = "server_executables",
+    srcs = [
+        "bin/init_server_basic",
+        "//services/seller_frontend_service:server",
+        "@com_github_grpc_grpc//test/cpp/util:grpc_cli",
+        "@jq",
+    ],
+    attributes = pkg_attributes(mode = "0555"),
+    prefix = "/server/bin",
+)
+
+server_binaries = [
+    ":server_executables",
+]
+
+pkg_zip(
+    name = "server_binaries",
+    srcs = server_binaries,
+)
+
+pkg_tar(
+    name = "server_binaries_tar",
+    srcs = server_binaries,
+)
+
+container_layer(
+    name = "server_binary_layer",
+    directory = "/",
+    tars = [
+        ":server_binaries_tar",
+    ],
+)
+
+pkg_files(
+    name = "etc_envoy_files",
+    srcs = [
+        "bin/envoy.yaml",
+        "//api:bidding_auction_servers_descriptor_set",
+    ],
+    attributes = pkg_attributes(mode = "0444"),
+    prefix = "/etc/envoy",
+    visibility = [
+        "//production/packaging:__subpackages__",
+    ],
+)
+
+pkg_tar(
+    name = "envoy_config_tar",
+    srcs = [
+        ":etc_envoy_files",
+    ],
+)
+
+container_layer(
+    name = "envoy_config_layer",
+    directory = "/",
+    tars = [
+        ":envoy_config_tar",
+    ],
+    visibility = [
+        "//production/packaging:__subpackages__",
+        "//services:__subpackages__",
+    ],
+)
+
+container_flatten(
+    name = "envoy_distroless_flat",
+    image = select({
+        "@platforms//cpu:arm64": "@envoy-distroless-arm64//image",
+        "@platforms//cpu:x86_64": "@envoy-distroless-amd64//image",
+    }),
+)
+
+container_layer(
+    name = "envoy_distroless_layer",
+    tars = [
+        ":envoy_distroless_flat.tar",
+    ],
+    visibility = [
+        "//production/packaging:__subpackages__",
+        "//services:__subpackages__",
+    ],
+)
+
+container_image(
+    name = "server_docker_image",
+    base = select({
+        "@platforms//cpu:arm64": "@runtime-cc-debian-arm64//image",
+        "@platforms//cpu:x86_64": "@runtime-cc-debian-amd64//image",
+    }),
+    cmd = [
+        "/server/bin/init_server_basic",
+    ],
+    entrypoint = ["sh"],
+    env = LOG_ENV_VARS,
+    labels = {"tee.launch_policy.log_redirect": "always"},
+    layers = [
+        ":server_binary_layer",
+        ":envoy_distroless_layer",
+        ":envoy_config_layer",
+    ],
+    # Envoy and SFE ports, respectively:
+    ports = [
+        "51052",
+        "50051",
+    ],
+)
+
+container_test(
+    name = "structure_test",
+    size = "large",
+    configs = ["test/structure.yaml"],
+    driver = "tar",
+    image = ":server_docker_image",
+)
+
+container_test(
+    name = "commands_test",
+    size = "large",
+    configs = ["test/commands.yaml"],
+    driver = "docker",
+    image = ":server_docker_image",
+)
+
+# server artifacts
+pkg_zip(
+    name = "server_artifacts",
+    srcs = server_binaries,
+)
+
+genrule(
+    name = "copy_to_dist",
+    srcs = [
+        ":server_artifacts",
+        ":server_docker_image.tar",
+        "//api:bidding_auction_servers_descriptor_set",
+    ],
+    outs = ["copy_to_dist.bin"],
+    cmd_bash = """cat << EOF > '$@'
+mkdir -p dist/debian
+cp $(execpath :server_artifacts) dist/debian/$$(basename $(RULEDIR))_artifacts.zip
+cp $(execpath :server_docker_image.tar) dist/debian/$$(basename $(RULEDIR))_image.tar
+cp $(execpath //api:bidding_auction_servers_descriptor_set) dist
+builders/tools/normalize-dist
+EOF""",
+    executable = True,
+    local = True,
+    message = "copying server artifacts to dist/debian directory",
+)

--- a/production/packaging/azure/seller_frontend_service/bin/envoy.yaml
+++ b/production/packaging/azure/seller_frontend_service/bin/envoy.yaml
@@ -1,0 +1,119 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+static_resources:
+  listeners:
+  - name: server_listener
+    per_connection_buffer_limit_bytes: 52428800
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 51052 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: envoy_router
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: [ "*" ]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: grpc_cluster, timeout: 5s }
+            response_headers_to_add:
+            - header:
+                key: 'x-allow-FLEDGE'
+                value: 'true'
+              append: false
+            - header:
+                key: 'x-fledge-bidding-signals-format-version'
+                value: '2'
+              append: false
+            - header:
+                key: 'Access-Control-Allow-Origin'
+                value: '*'
+              append: false
+          http_filters:
+          - name: envoy.filters.http.grpc_stats
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_stats.v3.FilterConfig
+              stats_for_all_methods: true
+              enable_upstream_stats: true
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+              pass_through_mode: false
+              cluster_min_healthy_percentages:
+                grpc_cluster: { value: 50 }
+              headers:
+              - name: ":path"
+                exact_match: "/healthcheck"
+          - name: envoy.filters.http.grpc_json_transcoder
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_json_transcoder.v3.GrpcJsonTranscoder
+              proto_descriptor: "/etc/envoy/bidding_auction_servers_descriptor_set.pb"
+              services:
+              - "privacy_sandbox.bidding_auction_servers.SellerFrontEnd"
+              print_options:
+                add_whitespace: true
+                always_print_primitive_fields: true
+                always_print_enums_as_ints: false
+                preserve_proto_field_names: false
+              request_validation_options:
+                reject_unknown_method: true
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            tls_certificates:
+            - certificate_chain: {filename: "/etc/envoy/cert.pem"}
+              private_key: {filename: "/etc/envoy/key.pem"}
+
+  clusters:
+  - name: grpc_cluster
+    connect_timeout: 2s
+    type: LOGICAL_DNS
+    lb_policy: ROUND_ROBIN
+    dns_lookup_family: V4_ONLY
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: { }
+    load_assignment:
+      cluster_name: grpc_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 50053
+    common_lb_config:
+      healthy_panic_threshold:
+        value: 50
+    health_checks:
+    - interval: 60s
+      timeout: 3s
+      no_traffic_interval: 60s
+      no_traffic_healthy_interval: 4s
+      unhealthy_threshold: 5
+      healthy_threshold: 5
+      grpc_health_check: { }

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -1,0 +1,46 @@
+#!/busybox/sh
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -x
+
+#########################################################################
+#                                                                       #
+#                            Envoy Startup                              #
+#                                                                       #
+#########################################################################
+
+# Start envoy.
+export original_dir=$(pwd)
+cd /etc/envoy
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=www.testenvoy.com"
+cd "$original_dir"
+
+/usr/local/bin/envoy --config-path /etc/envoy/envoy.yaml -l warn &
+sleep 2
+
+#########################################################################
+#                                                                       #
+#                             SFE Startup                               #
+#                                                                       #
+#########################################################################
+
+
+export GLOG_logtostderr=1
+export GLOG_stderrthreshold=0
+export GRPC_DNS_RESOLVER=native
+
+# Start the server.
+/server/bin/server  --init_config_client=true

--- a/production/packaging/azure/seller_frontend_service/test/commands.yaml
+++ b/production/packaging/azure/seller_frontend_service/test/commands.yaml
@@ -1,0 +1,24 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+# command tests require the docker toolchain
+commandTests:
+  - name: "server help"
+    command: "/server/bin/server"
+    args: ["--help"]
+    exitCode: 1

--- a/production/packaging/azure/seller_frontend_service/test/structure.yaml
+++ b/production/packaging/azure/seller_frontend_service/test/structure.yaml
@@ -1,0 +1,49 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# refer to docs at https://github.com/GoogleContainerTools/container-structure-test
+
+schemaVersion: 2.0.0
+
+fileExistenceTests:
+  - name: init_server_basic
+    path: /server/bin/init_server_basic
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: server
+    path: /server/bin/server
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: jq
+    path: /server/bin/jq
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: grpc_cli
+    path: /server/bin/grpc_cli
+    shouldExist: true
+    isExecutableBy: any
+
+  - name: envoy
+    path: /etc/envoy/envoy.yaml
+    shouldExist: true
+
+  - name: ca-certs
+    path: /etc/ssl/certs/ca-certificates.crt
+    shouldExist: true
+
+licenseTests:
+  - debian: true

--- a/production/packaging/build_and_test_all_in_docker
+++ b/production/packaging/build_and_test_all_in_docker
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright 2023 Google LLC
+# Copyright (C) Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +52,9 @@ declare -a AMI_REGIONS
 declare GCP_IMAGE_TAG
 declare GCP_IMAGE_REPO
 declare -i GCP_SKIP_IMAGE_UPLOAD=0
+declare AZURE_IMAGE_TAG
+declare AZURE_IMAGE_REPO
+declare -i AZURE_SKIP_IMAGE_UPLOAD=0
 declare -a BUILD_TARGETS=(
   "//tools/secure_invoke/..."
 )
@@ -67,7 +71,7 @@ usage:
     --service-path               [REQUIRED] Recognized values: auction_service, bidding_service, buyer_frontend_service, seller_frontend_service.
                                    Use multiple times to specify more than one service.
     --instance                   [REQUIRED] Recognized values: local, aws
-    --platform                   [REQUIRED] Recognized values: gcp, aws
+    --platform                   [REQUIRED] Recognized values: gcp, aws, azure
     --e2e                        Run e2e mode
     --build-flavor               Recognized values: prod, non_prod, inference_non_prod. Default: prod
                                    Use non_prod to enable verbose logging.
@@ -84,6 +88,11 @@ If platform is gcp:
     --gcp-skip-image-upload       Skip GCP image upload (and sha256 recording).
     --gcp-image-tag              [REQUIRED if no --gcp-skip-image-upload] (All lowercase) Custom image tag for GCP image.
     --gcp-image-repo             [REQUIRED if no --gcp-skip-image-upload] The target repo for TEE image upload. Ex: us-docker.pkg.dev/my-project-id/services
+
+If platform is azure:
+    --azure-skip-image-upload      Skip AZURE image upload (and sha256 recording).
+    --azure-image-tag              [REQUIRED if no --azure-skip-image-upload] (All lowercase) Custom image tag for Azure image.
+    --azure-image-repo             [REQUIRED if no --azure-skip-image-upload] The target repo for TEE image upload.
 
 environment variables (all optional):
     WORKSPACE                    Set the path to the workspace (repo root)
@@ -110,6 +119,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --gcp-skip-image-upload)
       GCP_SKIP_IMAGE_UPLOAD=1
+      shift
+      ;;
+    --azure-skip-image-upload)
+      AZURE_SKIP_IMAGE_UPLOAD=1
       shift
       ;;
     --no-platform-build)
@@ -148,6 +161,14 @@ while [[ $# -gt 0 ]]; do
       GCP_IMAGE_REPO="$2"
       shift 2 || usage
       ;;
+    --azure-image-tag)
+      AZURE_IMAGE_TAG="$2"
+      shift 2 || usage
+      ;;
+    --azure-image-repo)
+      AZURE_IMAGE_REPO="$2"
+      shift 2 || usage
+      ;;
     --verbose)
       VERBOSE=1
       shift
@@ -177,6 +198,18 @@ if [[ ${PLATFORM} = gcp ]]; then
     fi
     if [[ -z ${GCP_IMAGE_REPO} ]]; then
       printf "Error: --gcp-image-repo must be specified\n" &>/dev/stderr
+      usage
+    fi
+  fi
+fi
+if [[ ${PLATFORM} = azure ]]; then
+  if [[ ${AZURE_SKIP_IMAGE_UPLOAD} -eq 0 ]]; then
+    if [[ -z ${AZURE_IMAGE_TAG} ]]; then
+      printf "Error: --azure-image-tag must be specified\n" &>/dev/stderr
+      usage
+    fi
+    if [[ -z ${AZURE_IMAGE_REPO} ]]; then
+      printf "Error: --azure-image-repo must be specified\n" &>/dev/stderr
       usage
     fi
   fi
@@ -290,6 +323,27 @@ function build_service_for_gcp() {
   fi
 }
 
+function build_service_for_azure() {
+  declare -r service="$1"
+  # note: use relative path to dist
+  declare -r docker_image=dist/debian/${service}_image.tar
+  if ! [[ -s ${WORKSPACE}/${docker_image} ]]; then
+    printf "Error: docker image tar file not found: %s\n" "${docker_image}" &>/dev/stderr
+    exit 1
+  fi
+  create_azure_dist "${docker_image}"
+  if [[ ${AZURE_SKIP_IMAGE_UPLOAD} -eq 1 ]]; then
+    printf "==== Skipping default repo image upload. No image_digest will be recorded.  =====\n"
+  else
+    upload_image_to_repo \
+    "${service}" \
+    "${docker_image}" \
+    "${AZURE_IMAGE_REPO}" \
+    "${AZURE_IMAGE_TAG}" \
+    "${BUILD_FLAVOR}"
+  fi
+}
+
 function load_service_image() {
   declare -r service="$1"
   declare -r docker_image=dist/debian/${service}_image.tar
@@ -322,6 +376,13 @@ if [[ ${NO_PLATFORM_BUILD} -eq 0 ]]; then
       source  "${SCRIPT_DIR}"/gcp/lib_gcp_artifacts.sh
       for svc in "${SERVICES[@]}"; do
         build_service_for_gcp "${svc}"
+      done
+    ;;
+
+    azure)
+      source  "${SCRIPT_DIR}"/azure/lib_azure_artifacts.sh
+      for svc in "${SERVICES[@]}"; do
+        build_service_for_azure "${svc}"
       done
     ;;
     *)

--- a/services/common/clients/async_grpc/BUILD
+++ b/services/common/clients/async_grpc/BUILD
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# Copyright (C) Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +27,9 @@ cc_library(
             {
                 "@google_privacysandbox_servers_common//:aws_instance": [
                     "-DCLOUD_PLATFORM_AWS=1",
+                ],
+                "@google_privacysandbox_servers_common//:azure_instance": [
+                    "-DCLOUD_PLATFORM_AZURE=1",
                 ],
                 "@google_privacysandbox_servers_common//:gcp_instance": [
                     "-DCLOUD_PLATFORM_GCP=1",

--- a/services/common/clients/async_grpc/default_async_grpc_client.h
+++ b/services/common/clients/async_grpc/default_async_grpc_client.h
@@ -1,4 +1,5 @@
 //  Copyright 2022 Google LLC
+//  Copyright (C) Microsoft Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -51,6 +52,8 @@ class DefaultAsyncGrpcClient
         crypto_client_(crypto_client) {
 #if defined(CLOUD_PLATFORM_AWS)
     cloud_platform_ = server_common::CloudPlatform::kAws;
+#elif defined(CLOUD_PLATFORM_AZURE)
+    cloud_platform_ = server_common::CloudPlatform::kAzure;
 #elif defined(CLOUD_PLATFORM_GCP)
     cloud_platform_ = server_common::CloudPlatform::kGcp;
 #else

--- a/services/common/clients/auction_server/BUILD
+++ b/services/common/clients/auction_server/BUILD
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# Copyright (C) Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +26,9 @@ cc_library(
             {
                 "@google_privacysandbox_servers_common//:aws_instance": [
                     "-DCLOUD_PLATFORM_AWS=1",
+                ],
+                "@google_privacysandbox_servers_common//:azure_instance": [
+                    "-DCLOUD_PLATFORM_AZURE=1",
                 ],
                 "@google_privacysandbox_servers_common//:gcp_instance": [
                     "-DCLOUD_PLATFORM_GCP=1",

--- a/services/common/clients/bidding_server/BUILD
+++ b/services/common/clients/bidding_server/BUILD
@@ -1,4 +1,5 @@
 # Copyright 2023 Google LLC
+# Copyright (C) Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +26,9 @@ cc_library(
             {
                 "@google_privacysandbox_servers_common//:aws_instance": [
                     "-DCLOUD_PLATFORM_AWS=1",
+                ],
+                "@google_privacysandbox_servers_common//:azure_instance": [
+                    "-DCLOUD_PLATFORM_AZURE=1",
                 ],
                 "@google_privacysandbox_servers_common//:gcp_instance": [
                     "-DCLOUD_PLATFORM_GCP=1",

--- a/services/common/clients/config/trusted_server_config_client.cc
+++ b/services/common/clients/config/trusted_server_config_client.cc
@@ -1,4 +1,5 @@
 //  Copyright 2022 Google LLC
+//  Copyright (C) Microsoft Corporation. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -110,6 +111,11 @@ absl::Status TrustedServersConfigClient::Init(
 bool TrustedServersConfigClient::HasParameter(
     absl::string_view name) const noexcept {
   return config_entries_map_.contains(name);
+}
+
+bool TrustedServersConfigClient::HasParameterWithValue(
+    absl::string_view name) const noexcept {
+  return HasParameter(name) && config_entries_map_.at(name) != kEmptyValue;
 }
 
 absl::string_view TrustedServersConfigClient::GetStringParameter(

--- a/services/common/clients/config/trusted_server_config_client.h
+++ b/services/common/clients/config/trusted_server_config_client.h
@@ -72,6 +72,10 @@ class TrustedServersConfigClient {
   // Checks if a parameter is present in the config client.
   bool HasParameter(absl::string_view name) const noexcept;
 
+  // Checks if a parameter is present with a non-empty value in the config
+  // client.
+  bool HasParameterWithValue(absl::string_view name) const noexcept;
+
   // Fetches the string value for the specified config parameter.
   absl::string_view GetStringParameter(absl::string_view name) const noexcept;
 

--- a/services/common/clients/kv_server/BUILD
+++ b/services/common/clients/kv_server/BUILD
@@ -26,6 +26,9 @@ cc_library(
                 "@google_privacysandbox_servers_common//:aws_instance": [
                     "-DCLOUD_PLATFORM_AWS=1",
                 ],
+                "@google_privacysandbox_servers_common//:azure_instance": [
+                    "-DCLOUD_PLATFORM_AZURE=1",
+                ],
                 "@google_privacysandbox_servers_common//:gcp_instance": [
                     "-DCLOUD_PLATFORM_GCP=1",
                 ],

--- a/services/common/encryption/BUILD
+++ b/services/common/encryption/BUILD
@@ -1,4 +1,5 @@
 # Copyright 2022 Google LLC
+# Copyright (C) Microsoft Corporation. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,6 +35,9 @@ cc_library(
             {
                 "@google_privacysandbox_servers_common//:aws_instance": [
                     "-DCLOUD_PLATFORM_AWS=1",
+                ],
+                "@google_privacysandbox_servers_common//:azure_instance": [
+                    "-DCLOUD_PLATFORM_AZURE=1",
                 ],
                 "@google_privacysandbox_servers_common//:gcp_instance": [
                     "-DCLOUD_PLATFORM_GCP=1",

--- a/services/common/encryption/key_fetcher_factory.cc
+++ b/services/common/encryption/key_fetcher_factory.cc
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// Copyright (C) Microsoft Corporation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,6 +69,8 @@ CreatePublicKeyFetcher(TrustedServersConfigClient& config_client) {
       server_common::CloudPlatform::kLocal;
 #if defined(CLOUD_PLATFORM_AWS)
   cloud_platform = server_common::CloudPlatform::kAws;
+#elif defined(CLOUD_PLATFORM_AZURE)
+  cloud_platform = server_common::CloudPlatform::kAzure;
 #elif defined(CLOUD_PLATFORM_GCP)
   cloud_platform = server_common::CloudPlatform::kGcp;
 #endif
@@ -85,7 +88,7 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
     return std::make_unique<server_common::FakeKeyFetcherManager>();
   }
 
-  google::scp::cpio::PrivateKeyVendingEndpoint primary, secondary;
+  google::scp::cpio::PrivateKeyVendingEndpoint primary;
   primary.account_identity =
       config_client.GetStringParameter(PRIMARY_COORDINATOR_ACCOUNT_IDENTITY);
   primary.private_key_vending_service_endpoint =
@@ -94,14 +97,6 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
   primary.service_region =
       config_client.GetStringParameter(PRIMARY_COORDINATOR_REGION);
 
-  secondary.account_identity =
-      config_client.GetStringParameter(SECONDARY_COORDINATOR_ACCOUNT_IDENTITY);
-  secondary.private_key_vending_service_endpoint =
-      config_client.GetStringParameter(
-          SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT);
-  secondary.service_region =
-      config_client.GetStringParameter(SECONDARY_COORDINATOR_REGION);
-
   if (config_client.HasParameter(GCP_PRIMARY_WORKLOAD_IDENTITY_POOL_PROVIDER)) {
     PS_VLOG(3) << "Found GCP Workload Identity Pool Provider, proceeding...";
     primary.gcp_private_key_vending_service_cloudfunction_url =
@@ -109,18 +104,37 @@ std::unique_ptr<KeyFetcherManagerInterface> CreateKeyFetcherManager(
             GCP_PRIMARY_KEY_SERVICE_CLOUD_FUNCTION_URL);
     primary.gcp_wip_provider = config_client.GetStringParameter(
         GCP_PRIMARY_WORKLOAD_IDENTITY_POOL_PROVIDER);
+  }
 
-    secondary.gcp_private_key_vending_service_cloudfunction_url =
+  std::vector<google::scp::cpio::PrivateKeyVendingEndpoint> secondaries{};
+  if (config_client.HasParameterWithValue(
+          SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT)) {
+    google::scp::cpio::PrivateKeyVendingEndpoint secondary;
+
+    secondary.account_identity = config_client.GetStringParameter(
+        SECONDARY_COORDINATOR_ACCOUNT_IDENTITY);
+    secondary.private_key_vending_service_endpoint =
         config_client.GetStringParameter(
-            GCP_SECONDARY_KEY_SERVICE_CLOUD_FUNCTION_URL);
-    secondary.gcp_wip_provider = config_client.GetStringParameter(
-        GCP_SECONDARY_WORKLOAD_IDENTITY_POOL_PROVIDER);
+            SECONDARY_COORDINATOR_PRIVATE_KEY_ENDPOINT);
+    secondary.service_region =
+        config_client.GetStringParameter(SECONDARY_COORDINATOR_REGION);
+
+    if (config_client.HasParameter(
+            GCP_PRIMARY_WORKLOAD_IDENTITY_POOL_PROVIDER)) {
+      secondary.gcp_private_key_vending_service_cloudfunction_url =
+          config_client.GetStringParameter(
+              GCP_SECONDARY_KEY_SERVICE_CLOUD_FUNCTION_URL);
+      secondary.gcp_wip_provider = config_client.GetStringParameter(
+          GCP_SECONDARY_WORKLOAD_IDENTITY_POOL_PROVIDER);
+    }
+
+    secondaries.push_back(secondary);
   }
 
   absl::Duration private_key_ttl = absl::Seconds(
       config_client.GetIntParameter(PRIVATE_KEY_CACHE_TTL_SECONDS));
   std::unique_ptr<PrivateKeyFetcherInterface> private_key_fetcher =
-      server_common::PrivateKeyFetcherFactory::Create(primary, {secondary},
+      server_common::PrivateKeyFetcherFactory::Create(primary, secondaries,
                                                       private_key_ttl);
 
   absl::Duration key_refresh_flow_run_freq = absl::Seconds(

--- a/services/seller_frontend_service/util/config_param_parser.cc
+++ b/services/seller_frontend_service/util/config_param_parser.cc
@@ -1,4 +1,5 @@
 //   Copyright 2022 Google LLC
+//   Copyright (C) Microsoft Corporation. All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -87,6 +88,8 @@ ParseIgOwnerToBfeDomainMap(absl::string_view ig_owner_to_bfe_domain) {
       bfe_endpoint.cloud_platform = server_common::CloudPlatform::kGcp;
     } else if (absl::EqualsIgnoreCase(cloud_platform, "AWS")) {
       bfe_endpoint.cloud_platform = server_common::CloudPlatform::kAws;
+    } else if (absl::EqualsIgnoreCase(cloud_platform, "AZURE")) {
+      bfe_endpoint.cloud_platform = server_common::CloudPlatform::kAzure;
     } else if (absl::EqualsIgnoreCase(cloud_platform, "LOCAL")) {
       bfe_endpoint.cloud_platform = server_common::CloudPlatform::kLocal;
     } else {

--- a/services/seller_frontend_service/util/config_param_parser_test.cc
+++ b/services/seller_frontend_service/util/config_param_parser_test.cc
@@ -1,4 +1,5 @@
 //   Copyright 2022 Google LLC
+//   Copyright (C) Microsoft Corporation. All rights reserved.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@
 
 #include "services/seller_frontend_service/util/config_param_parser.h"
 
+#include <array>
 #include <memory>
 #include <string>
 
@@ -43,19 +45,19 @@ constexpr absl::string_view kBuyerHostMapForMultipleBuyers =
     {
       "https://bid2.com": {
         "url": "dns:///bfe-dev.buyer2-frontend.com:443",
-        "cloudPlatform": "GCP"
+        "cloudPlatform": "AZURE"
       },
       "https://bid3.com": {
         "url": "dns:///bfe-dev.buyer3-frontend.com:443",
-        "cloudPlatform": "AWS"
+        "cloudPlatform": "GCP"
       },
       "https://bid4.com": {
         "url": "dns:///bfe-dev.buyer4-frontend.com:443",
-        "cloudPlatform": "GCP"
+        "cloudPlatform": "AWS"
       },
       "https://bid5.com": {
         "url": "dns:///bfe-dev.buyer5-frontend.com:443",
-        "cloudPlatform": "AWS"
+        "cloudPlatform": "AZURE"
       },
       "https://bid6.com": {
         "url": "dns:///bfe-dev.buyer6-frontend.com:443",
@@ -179,8 +181,9 @@ TEST(StartupParamParserTest, ParseMultiBuyerMap) {
         std::string url =
             absl::StrCat("dns:///bfe-dev.buyer", std::to_string(buyer_number),
                          "-frontend.com:443");
-        CloudPlatform platform =
-            (buyer_number % 2 == 0) ? CloudPlatform::kGcp : CloudPlatform::kAws;
+        constexpr std::array<CloudPlatform, 3> platforms = {
+            CloudPlatform::kGcp, CloudPlatform::kAws, CloudPlatform::kAzure};
+        CloudPlatform platform = platforms[buyer_number % platforms.size()];
         EXPECT_EQ(it->second.endpoint, url);
         EXPECT_EQ(it->second.cloud_platform, platform);
         actual_buyer_async_client = class_under_test.Get(current_ig_owner);

--- a/services/seller_frontend_service/util/key_fetcher_utils.cc
+++ b/services/seller_frontend_service/util/key_fetcher_utils.cc
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// Copyright (C) Microsoft Corporation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,6 +56,8 @@ ParseCloudPlatformPublicKeysMap(
       cloud_platform = server_common::CloudPlatform::kGcp;
     } else if (absl::EqualsIgnoreCase(cloud_platform_str, "AWS")) {
       cloud_platform = server_common::CloudPlatform::kAws;
+    } else if (absl::EqualsIgnoreCase(cloud_platform_str, "AZURE")) {
+      cloud_platform = server_common::CloudPlatform::kAzure;
     } else {
       return absl::InvalidArgumentError(
           absl::StrCat(kUnsupportedCloudPlatformValue, cloud_platform_str));

--- a/services/seller_frontend_service/util/key_fetcher_utils_test.cc
+++ b/services/seller_frontend_service/util/key_fetcher_utils_test.cc
@@ -1,4 +1,5 @@
 // Copyright 2023 Google LLC
+// Copyright (C) Microsoft Corporation. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,18 +29,21 @@ TEST(KeyFetcherUtilsTest, ParseCloudPlatformPublicKeysMap_ValidInput) {
   absl::string_view per_platform_public_key_endpoints = R"json(
 {
   "GCP": "https://publickeyservice.foo/v1alpha/publicKeys",
-  "AWS": "https://publickeyservice.cloudfront.net/v1alpha/publicKeys"
+  "AWS": "https://publickeyservice.cloudfront.net/v1alpha/publicKeys",
+  "AZURE": "https://publickeyservice.bar/v1alpha/publicKeys"
 }
 )json";
 
   auto map = ParseCloudPlatformPublicKeysMap(per_platform_public_key_endpoints);
   ASSERT_TRUE(map.ok());
-  EXPECT_EQ(map->size(), 2);
+  EXPECT_EQ(map->size(), 3);
 
   EXPECT_EQ((*map)[server_common::CloudPlatform::kGcp][0],
             "https://publickeyservice.foo/v1alpha/publicKeys");
   EXPECT_EQ((*map)[server_common::CloudPlatform::kAws][0],
             "https://publickeyservice.cloudfront.net/v1alpha/publicKeys");
+  EXPECT_EQ((*map)[server_common::CloudPlatform::kAzure][0],
+            "https://publickeyservice.bar/v1alpha/publicKeys");
 }
 
 TEST(KeyFetcherUtilsTest, ParseCloudPlatformPublicKeysMap_InvalidJson) {


### PR DESCRIPTION
This is a updated version of [the previous PR](https://github.com/privacysandbox/bidding-auction-servers/pull/9) because the latest commit at the time (v3.0.0) is now outdated.
It is created based on our current codebase which is based on v3.4.0, so we set the v3.4.0 release as the target.

The previous PR is left as it is because the branch is still used by [our demo](https://github.com/microsoft/azure-bidding-and-auction-services-demo).

[The new PR for data-plane-shared-libraries](https://github.com/KenGordon/data-plane-shared-libraries/pull/24) targets a branch with hash 1fbac46 (used by v3.4.0) in our fork because we can't create a PR against commits without branch name or tag in https://github.com/privacysandbox/data-plane-shared-libraries.

This PR targets a copy of the v3.4.0 release in our fork as well for consistency.

---
# Adding Azure support

This PR is adding support for enabling deployment of Bidding and Auction Services on Azure.

Azure Privacy Sandbox architecture: https://1drv.ms/w/s!AmI-86sms1pYqJ5Uqgo5Qv2Ynmrcmw?e=BDC8BH
(We'll make a PR for the document in https://github.com/privacysandbox/protected-auction-services-docs/tree/main in future)

Now B&A services can fetch private and public HPKE keys from an Azure KMS, specifically designed to support the B&A services, and handle test requests.

To try this changes locally, please visit [here](https://github.com/microsoft/azure-bidding-and-auction-services-demo).

The PR for data-plane-shared-libraries repository: https://github.com/KenGordon/data-plane-shared-libraries/pull/24
azure-privacy-sandbox-kms branch that works with this PR: https://github.com/microsoft/azure-privacy-sandbox-kms/tree/add-azure-support-v3.4.0

## Changes

- Add Azure support
    - Add Azure configurations. e.g. `--platform=azure` (for Bazel), `kAzure` (C++ enum value).
    - Add Azure scripts and configuration files for  `production/packaging`
    - Update some test cases to add test coverage for `kAzure`.

## TODOs for future PRs

- Add scripts to Deploy B&A services to Azure
