### PR TITLE
Get envoy TLS cert from AKV

### DIFF
--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -26,12 +26,7 @@ set -x
 
 # Parameters to be deleted
 # - MANAGED_IDENTITY_CLIENT_ID: This is to support development on azure instances with multiple user-assigned identities.
-# - AKV_RESOURCE_GROUP: Resource group that has AKV to store TLS certs.
 # - SELF_SIGNED_ENVOY_CERT
-
-# Parameters in production
-# - METADATA_OPERATOR
-# - METADATA_ENV
 
 if [ "$SELF_SIGNED_ENVOY_CERT" == "true" ]; then
     cur_dir=$(pwd)
@@ -46,25 +41,35 @@ else
     # Get subscription ID (to be used for getting the key vault name)
     SUBSCRIPTION_ID=$(wget -q --header "Metadata:true"  --output-document - \
     http://169.254.169.254/metadata/instance?api-version=2021-02-01 | \
-    jq -r .compute.subscriptionId)
+    /server/bin/jq -r .compute.subscriptionId)
 
-    # The following would be handy way to determin key vault name, but would be 54 characters which is more than the
-    # limit. A vault's name must be between 3-24 alphanumeric characters.
-    # KEY_VAULT_NAME=protectedaudience-${SUBSCRIPTION_ID}
+    # The key vault needs to be named as the following so that
+    # it can be specified with subscription ID.
+    # 'pa' stands for Protected Audience.
+    # We truncate SUBSCRIPTION_ID_NO_DASH from 36 to 22 so that the name fits in the max length (24 characters).
+    # Strictly speaking collisions could happen among subscriptions, but it should be fine because even in such cases
+    # it would be detected when creating the key vault.
+    SUBSCRIPTION_ID_NO_DASH=${SUBSCRIPTION_ID//-}
+    echo "TEST_TAKURO: SUBSCRIPTION_ID_NO_DASH: $SUBSCRIPTION_ID_NO_DASH"
+    KEY_VAULT_NAME=pa${SUBSCRIPTION_ID_NO_DASH:0:22}
 
-    # Get credentials (to be used for getting the key vault name)
+    echo "TEST_TAKURO: key vault name: $KEY_VAULT_NAME"
+
+    # Get credentials (to be used for getting operator and environment)
     ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
     "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
     | /server/bin/jq -r '.access_token')
 
-    RESOURCE_GROUP=${AKV_RESOURCE_GROUP:-protected-audience-akv}
+    RESOURCE_ID=$(wget -q --header "Metadata:true"  --output-document - \
+    http://169.254.169.254/metadata/instance?api-version=2021-02-01 | jq .compute.resourceId -r)
 
-    # Get key vault name
-    # https://learn.microsoft.com/en-us/rest/api/keyvault/keyvault/vaults/list-by-resource-group?view=rest-keyvault-keyvault-2022-07-01&tabs=HTTP
-    KEY_VAULT_NAME=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.KeyVault/vaults?api-version=2022-07-01 \
-    | /server/bin/jq -r ".value.[0].name")
+    OPERATOR=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+    https://management.azure.com${RESOURCE_ID}/providers/Microsoft.Resources/tags/default?api-version=2021-04-01 \
+    | /server/bin/jq -r '.properties.tags.operator')
 
+    ENV=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+    https://management.azure.com${RESOURCE_ID}/providers/Microsoft.Resources/tags/default?api-version=2021-04-01 \
+    | /server/bin/jq -r '.properties.tags.environment')
 
     # Get credentials (to be used for fetching secrets)
     ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
@@ -74,13 +79,13 @@ else
     # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
     ## TLS Key
     wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${METADATA_OPERATOR}-${METADATA_ENV}-SFE_TLS_KEY?api-version=7.4 \
-    | /server/bin/jq -r ".value" 
+    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${OPERATOR}-${ENV}-SFE_TLS_KEY?api-version=7.4 \
+    | /server/bin/jq -r ".value"
     | base64 -d > /etc/envoy/key.pem
 
     ## TLS Cert
     wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${METADATA_OPERATOR}-${METADATA_ENV}-SFE_TLS_CERT?api-version=7.4 \
+    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${OPERATOR}-${ENV}-SFE_TLS_CERT?api-version=7.4 \
     | /server/bin/jq -r ".value"
     | base64 -d > /etc/envoy/cert.pem
 fi

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -24,44 +24,23 @@ set -x
 
 # Start envoy.
 
-# Parameters
-# - AZURE_BA_METADATA_OPERATOR
-# - AZURE_BA_METADATA_ENVIRONMENT
-# - AZURE_BA_PARAM_KEY_VAULT_URL: URL like "https://${KEY_VAULT_NAME}.vault.azure.net"
-# - AZURE_BA_PARAM_GET_TOKEN_URL: URL like "http://$IDP_HOST/metadata/identity/oauth2/token?api-version=2018-02-01"
+# Get credentials (to be used for fetching secrets)
+ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
+"${AZURE_BA_PARAM_GET_TOKEN_URL_AKV}" \
+| /server/bin/jq -r '.access_token')
 
-# Parameters to be deleted
-# - MANAGED_IDENTITY_CLIENT_ID: This is to support development on azure instances with multiple user-assigned identities.
-# - SELF_SIGNED_ENVOY_CERT
+# Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
+## TLS Key
+wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_KEY?api-version=7.4 \
+| /server/bin/jq -r ".value" \
+| base64 -d > /etc/envoy/key.pem
 
-if [ "$SELF_SIGNED_ENVOY_CERT" == "true" ]; then
-    cur_dir=$(pwd)
-    cd /etc/envoy
-    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=www.testenvoy.com"
-    cd "$curl_dir"
-else
-    if [ -n "$MANAGED_IDENTITY_CLIENT_ID" ]; then
-        MANAGED_IDENTITY_CLIENT_ID_PARAM="&client_id=${MANAGED_IDENTITY_CLIENT_ID}"
-    fi
-
-    # Get credentials (to be used for fetching secrets)
-    ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
-    "${AZURE_BA_PARAM_GET_TOKEN_URL}&resource=https%3A%2F%2Fvault.azure.net${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
-    | /server/bin/jq -r '.access_token')
-
-    # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
-    ## TLS Key
-    wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    ${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_KEY?api-version=7.4 \
-    | /server/bin/jq -r ".value"
-    | base64 -d > /etc/envoy/key.pem
-
-    ## TLS Cert
-    wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    ${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_CERT?api-version=7.4 \
-    | /server/bin/jq -r ".value"
-    | base64 -d > /etc/envoy/cert.pem
-fi
+## TLS Cert
+wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_CERT?api-version=7.4 \
+| /server/bin/jq -r ".value" \
+| base64 -d > /etc/envoy/cert.pem
 
 /usr/local/bin/envoy --config-path /etc/envoy/envoy.yaml -l warn &
 sleep 2

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -32,13 +32,13 @@ ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
 # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
 ## TLS Key
 wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_KEY?api-version=7.4 \
+${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SfeTlsKey?api-version=7.4 \
 | /server/bin/jq -r ".value" \
 | base64 -d > /etc/envoy/key.pem
 
 ## TLS Cert
 wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_CERT?api-version=7.4 \
+${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SfeTlsCert?api-version=7.4 \
 | /server/bin/jq -r ".value" \
 | base64 -d > /etc/envoy/cert.pem
 

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -26,7 +26,7 @@ set -x
 
 # Get credentials (to be used for fetching secrets)
 ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
-"${AZURE_BA_PARAM_GET_TOKEN_URL_AKV}" \
+"${AZURE_BA_PARAM_GET_TOKEN_URL}?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net%2F" \
 | /server/bin/jq -r '.access_token')
 
 # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -24,6 +24,11 @@ set -x
 
 # Start envoy.
 
+# Parameters
+# - AZURE_BA_METADATA_OPERATOR
+# - AZURE_BA_METADATA_ENVIRONMENT
+# - AZURE_BA_PARAM_KEY_VAULT_URL: URL like "https://${KEY_VAULT_NAME}.vault.azure.net"
+
 # Parameters to be deleted
 # - MANAGED_IDENTITY_CLIENT_ID: This is to support development on azure instances with multiple user-assigned identities.
 # - SELF_SIGNED_ENVOY_CERT
@@ -38,39 +43,6 @@ else
         MANAGED_IDENTITY_CLIENT_ID_PARAM="&client_id=${MANAGED_IDENTITY_CLIENT_ID}"
     fi
 
-    # Get subscription ID (to be used for getting the key vault name)
-    SUBSCRIPTION_ID=$(wget -q --header "Metadata:true"  --output-document - \
-    http://169.254.169.254/metadata/instance?api-version=2021-02-01 | \
-    /server/bin/jq -r .compute.subscriptionId)
-
-    # The key vault needs to be named as the following so that
-    # it can be specified with subscription ID.
-    # 'pa' stands for Protected Audience.
-    # We truncate SUBSCRIPTION_ID_NO_DASH from 36 to 22 so that the name fits in the max length (24 characters).
-    # Strictly speaking collisions could happen among subscriptions, but it should be fine because even in such cases
-    # it would be detected when creating the key vault.
-    SUBSCRIPTION_ID_NO_DASH=${SUBSCRIPTION_ID//-}
-    echo "TEST_TAKURO: SUBSCRIPTION_ID_NO_DASH: $SUBSCRIPTION_ID_NO_DASH"
-    KEY_VAULT_NAME=pa${SUBSCRIPTION_ID_NO_DASH:0:22}
-
-    echo "TEST_TAKURO: key vault name: $KEY_VAULT_NAME"
-
-    # Get credentials (to be used for getting operator and environment)
-    ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
-    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
-    | /server/bin/jq -r '.access_token')
-
-    RESOURCE_ID=$(wget -q --header "Metadata:true"  --output-document - \
-    http://169.254.169.254/metadata/instance?api-version=2021-02-01 | jq .compute.resourceId -r)
-
-    OPERATOR=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://management.azure.com${RESOURCE_ID}/providers/Microsoft.Resources/tags/default?api-version=2021-04-01 \
-    | /server/bin/jq -r '.properties.tags.operator')
-
-    ENV=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://management.azure.com${RESOURCE_ID}/providers/Microsoft.Resources/tags/default?api-version=2021-04-01 \
-    | /server/bin/jq -r '.properties.tags.environment')
-
     # Get credentials (to be used for fetching secrets)
     ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
     "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
@@ -79,13 +51,13 @@ else
     # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
     ## TLS Key
     wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${OPERATOR}-${ENV}-SFE_TLS_KEY?api-version=7.4 \
+    ${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_KEY?api-version=7.4 \
     | /server/bin/jq -r ".value"
     | base64 -d > /etc/envoy/key.pem
 
     ## TLS Cert
     wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${OPERATOR}-${ENV}-SFE_TLS_CERT?api-version=7.4 \
+    ${AZURE_BA_PARAM_KEY_VAULT_URL}/secrets/${AZURE_BA_METADATA_OPERATOR}-${AZURE_BA_METADATA_ENVIRONMENT}-SFE_TLS_CERT?api-version=7.4 \
     | /server/bin/jq -r ".value"
     | base64 -d > /etc/envoy/cert.pem
 fi

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -62,7 +62,7 @@ else
     # Get key vault name
     # https://learn.microsoft.com/en-us/rest/api/keyvault/keyvault/vaults/list-by-resource-group?view=rest-keyvault-keyvault-2022-07-01&tabs=HTTP
     KEY_VAULT_NAME=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://learn.microsoft.com/en-us/rest/api/keyvault/keyvault/vaults/list-by-resource-group?view=rest-keyvault-keyvault-2022-07-01&tabs=HTTP \
+    https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.KeyVault/vaults?api-version=2022-07-01 \
     | /server/bin/jq -r ".value.[0].name")
 
 

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -28,6 +28,7 @@ set -x
 # - AZURE_BA_METADATA_OPERATOR
 # - AZURE_BA_METADATA_ENVIRONMENT
 # - AZURE_BA_PARAM_KEY_VAULT_URL: URL like "https://${KEY_VAULT_NAME}.vault.azure.net"
+# - AZURE_BA_PARAM_GET_TOKEN_URL: URL like "http://$IDP_HOST/metadata/identity/oauth2/token?api-version=2018-02-01"
 
 # Parameters to be deleted
 # - MANAGED_IDENTITY_CLIENT_ID: This is to support development on azure instances with multiple user-assigned identities.
@@ -45,7 +46,7 @@ else
 
     # Get credentials (to be used for fetching secrets)
     ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
-    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
+    "${AZURE_BA_PARAM_GET_TOKEN_URL}&resource=https%3A%2F%2Fvault.azure.net${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
     | /server/bin/jq -r '.access_token')
 
     # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -23,10 +23,32 @@ set -x
 #########################################################################
 
 # Start envoy.
-export original_dir=$(pwd)
-cd /etc/envoy
-openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=www.testenvoy.com"
-cd "$original_dir"
+
+if [ "$AKV_TLS_CERTS" != "true" ]; then
+    export cur_dir=$(pwd)
+    cd /etc/envoy
+    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=www.testenvoy.com"
+    cd "$curl_dir"
+else
+    if [ -n "$MANAGED_IDENTITY_CLIENT_ID" ]; then
+        MANAGED_IDENTITY_CLIENT_ID_PARAM="&client_id=${MANAGED_IDENTITY_CLIENT_ID}"
+    fi
+    # Get credentials (to be used for fetching secrets)
+    export ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
+    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
+    | /server/bin/jq -r '.access_token')
+
+    # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
+    ## TLS Key
+    wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/sfeEnvoyTlsCertKey?api-version=7.4 \
+    | /server/bin/jq -r ".value" > /etc/envoy/key.pem
+
+    ## TLS Cert
+    wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/sfeEnvoyTlsCert?api-version=7.4 \
+    | /server/bin/jq -r ".value" > /etc/envoy/cert.pem
+fi
 
 /usr/local/bin/envoy --config-path /etc/envoy/envoy.yaml -l warn &
 sleep 2

--- a/production/packaging/azure/seller_frontend_service/bin/init_server_basic
+++ b/production/packaging/azure/seller_frontend_service/bin/init_server_basic
@@ -24,8 +24,17 @@ set -x
 
 # Start envoy.
 
-if [ "$AKV_TLS_CERTS" != "true" ]; then
-    export cur_dir=$(pwd)
+# Parameters to be deleted
+# - MANAGED_IDENTITY_CLIENT_ID: This is to support development on azure instances with multiple user-assigned identities.
+# - AKV_RESOURCE_GROUP: Resource group that has AKV to store TLS certs.
+# - SELF_SIGNED_ENVOY_CERT
+
+# Parameters in production
+# - METADATA_OPERATOR
+# - METADATA_ENV
+
+if [ "$SELF_SIGNED_ENVOY_CERT" == "true" ]; then
+    cur_dir=$(pwd)
     cd /etc/envoy
     openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=StateName/L=CityName/O=CompanyName/OU=CompanySectionName/CN=www.testenvoy.com"
     cd "$curl_dir"
@@ -33,21 +42,47 @@ else
     if [ -n "$MANAGED_IDENTITY_CLIENT_ID" ]; then
         MANAGED_IDENTITY_CLIENT_ID_PARAM="&client_id=${MANAGED_IDENTITY_CLIENT_ID}"
     fi
+
+    # Get subscription ID (to be used for getting the key vault name)
+    SUBSCRIPTION_ID=$(wget -q --header "Metadata:true"  --output-document - \
+    http://169.254.169.254/metadata/instance?api-version=2021-02-01 | \
+    jq -r .compute.subscriptionId)
+
+    # The following would be handy way to determin key vault name, but would be 54 characters which is more than the
+    # limit. A vault's name must be between 3-24 alphanumeric characters.
+    # KEY_VAULT_NAME=protectedaudience-${SUBSCRIPTION_ID}
+
+    # Get credentials (to be used for getting the key vault name)
+    ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
+    "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
+    | /server/bin/jq -r '.access_token')
+
+    RESOURCE_GROUP=${AKV_RESOURCE_GROUP:-protected-audience-akv}
+
+    # Get key vault name
+    # https://learn.microsoft.com/en-us/rest/api/keyvault/keyvault/vaults/list-by-resource-group?view=rest-keyvault-keyvault-2022-07-01&tabs=HTTP
+    KEY_VAULT_NAME=$(wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
+    https://learn.microsoft.com/en-us/rest/api/keyvault/keyvault/vaults/list-by-resource-group?view=rest-keyvault-keyvault-2022-07-01&tabs=HTTP \
+    | /server/bin/jq -r ".value.[0].name")
+
+
     # Get credentials (to be used for fetching secrets)
-    export ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
+    ACCESS_TOKEN=$(wget -q --header "Metadata:true"  --output-document -  \
     "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fvault.azure.net${MANAGED_IDENTITY_CLIENT_ID_PARAM}" \
     | /server/bin/jq -r '.access_token')
 
     # Get our secrets, parse, decode, and write the secret strings to files that the Envoy config will read.
     ## TLS Key
     wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/sfeEnvoyTlsCertKey?api-version=7.4 \
-    | /server/bin/jq -r ".value" > /etc/envoy/key.pem
+    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${METADATA_OPERATOR}-${METADATA_ENV}-SFE_TLS_KEY?api-version=7.4 \
+    | /server/bin/jq -r ".value" 
+    | base64 -d > /etc/envoy/key.pem
 
     ## TLS Cert
     wget -q --header "Authorization: Bearer ${ACCESS_TOKEN}" --output-document - \
-    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/sfeEnvoyTlsCert?api-version=7.4 \
-    | /server/bin/jq -r ".value" > /etc/envoy/cert.pem
+    https://${KEY_VAULT_NAME}.vault.azure.net/secrets/${METADATA_OPERATOR}-${METADATA_ENV}-SFE_TLS_CERT?api-version=7.4 \
+    | /server/bin/jq -r ".value"
+    | base64 -d > /etc/envoy/cert.pem
 fi
 
 /usr/local/bin/envoy --config-path /etc/envoy/envoy.yaml -l warn &

--- a/third_party/container_deps.bzl
+++ b/third_party/container_deps.bzl
@@ -35,7 +35,7 @@ def container_deps():
         "envoy-distroless": {
             "arch_hashes": {
                 # v1.23.1
-                "amd64": "e2c642bc6949cb3053810ca14524324d7daf884a0046d7173e46e2b003144f1d", # @envoy-distroless-amd64-repo-digests-replace-marker@
+                "amd64": "e2c642bc6949cb3053810ca14524324d7daf884a0046d7173e46e2b003144f1d",  # @envoy-distroless-amd64-repo-digests-replace-marker@
                 "arm64": "7763f6325882122afb1beb6ba0a047bed318368f9656fd9c1df675f3d89f1dbe",
             },
             "registry": "docker.io",
@@ -44,7 +44,7 @@ def container_deps():
         "runtime-cc-debian": {
             # debug build so we can use 'sh'
             "arch_hashes": {
-                "amd64": "6865ad48467c89c3c3524d4c426f52ad12d9ab7dec31fad31fae69da40eb6445", # @runtime-cc-debian-amd64-repo-digests-replace-marker@
+                "amd64": "6865ad48467c89c3c3524d4c426f52ad12d9ab7dec31fad31fae69da40eb6445",  # @runtime-cc-debian-amd64-repo-digests-replace-marker@
                 "arm64": "3c399c24b13bfef7e38257831b1bb05cbddbbc4d0327df87a21b6fbbb2480bc9",
             },
             "registry": "gcr.io",


### PR DESCRIPTION
Get envoy TSL cert and key from Azure Key Vault following the GCP implementation.
Introduce AZURE_BA_PARAM_KEY_VAULT_URL, AZURE_BA_METADATA_OPERATOR, and AZURE_BA_METADATA_ENVIRONMENT.

GCP implementation (with Azure terminology) is:
- Fetch subscription ID from metadata service (local server to provide metadata) to specify AKV's instance.
- Fetch 'operator' and 'environment' value from metadata service. (metadata service has key value store feature)
- They are used to specify key name and cert name


We concluded we can't do the exact same because ACI doesn't have metadata service that meet the requirement.
Now we won't use ACI, but for now we stick to environment variable instead of metadata servicer-ish solution, because environment variable is widely available and would help configuration for local development.
